### PR TITLE
Automatically add _serialized field

### DIFF
--- a/assets/js/App/AppListController.js
+++ b/assets/js/App/AppListController.js
@@ -18,9 +18,8 @@
           $scope.appList = appList;
           $scope._loaded(false);
         }, function(err) {
-          // FIXME: What to do in case of error
           console.error(err);
-          alert('appList fetch err, what now?');
+          $scope.appListError = true;
           $scope._loaded(false);
         });
 

--- a/assets/js/App/AppListView.html
+++ b/assets/js/App/AppListView.html
@@ -25,13 +25,17 @@
   </thead>
   <tbody class="hideLoading">
     <tr data-app-item="edit" data-ng-repeat="app in appList | orderBy : nameOrder | filter:search"></tr>
-    <tr data-ng-hide="appList.length">
+    <tr data-ng-hide="appList.length || appListError">
       <td colspan="2">This list is empty. <a href="/add">Please add a repo.</a></td>
     </tr>
   </tbody>
   <tfoot>
-    <td colspan="2">
+    <td data-ng-hide="appListError" class="hideLoading" colspan="2">
       <a href="/add" class="btn btn-primary pull-right"><span class="glyphicon glyphicon-plus"></span> Add to List</a>
     </td>
   </tfoot>
 </table>
+
+<div data-ng-show="appListError">
+  An error occurred while retrieving the application list.
+</div>

--- a/lib/controllers/api/coupling.js
+++ b/lib/controllers/api/coupling.js
@@ -80,7 +80,7 @@
 
     var newExpList = getNewExperiments(expList, dbExpList)
       , modifiedExpDescList = getModifiedDescriptions(expList, dbExpList)
-      , edited = isEdited(modifiedExpDescList, newExpList);
+      , edited = isEdited(modifiedExpDescList, newExpList, doc);
 
     /* If there are new experiments or modified descriptions, then update the database and return the experiments with
        these updates.  Otherwise, just return the experiments from the database. */
@@ -147,6 +147,7 @@
 
   /**
    * Create the list of new experiments.
+   *
    * @param expList
    * @param origExpList
    * @returns {Array}
@@ -167,6 +168,7 @@
 
   /**
    * Create list of modified experiment descriptions.
+   *
    * @param expList
    * @param origExpList
    * @returns {Array}
@@ -184,6 +186,7 @@
 
   /**
    * Create new models for each of the new experiments and add them to the document.
+   *
    * @param newExpList
    * @param doc
    */
@@ -203,6 +206,7 @@
 
   /**
    * Update the document with the modified experiment descriptions.
+   *
    * @param modifiedExpDescList
    * @param doc
    */
@@ -214,12 +218,14 @@
   }
 
   /**
-   * Checks if the experiment list in the document has changed.
+   * Checks if the app document has changed.  Returning true will cause the document to be
+   * updated in the Database.
+   *
    * @param modifiedExpDescList
    * @param newExpList
    * @returns {boolean}
    */
-  function isEdited(modifiedExpDescList, newExpList) {
+  function isEdited(modifiedExpDescList, newExpList, doc) {
     var edited = false;
 
     if (modifiedExpDescList.length > 0) {
@@ -230,6 +236,13 @@
     if (newExpList.length > 0) {
       edited = true;
       debug('NewList: ', newExpList);
+    }
+
+    /* Apps created or last updated with Feature v0.8.1 and prior do not have the _serialized field, which is required
+       as of v0.9.0. So, if the _serialized field does not exist for an app, then automatically migrate the app data
+       by forcing the document to be rewritten to the DB which will cause the _serialized field to be added. */
+    if (!doc._serialized) {
+      edited = true;
     }
 
     return edited;

--- a/lib/models/app/virtuals.js
+++ b/lib/models/app/virtuals.js
@@ -13,12 +13,17 @@
     });
 
     Schema.virtual('serialized').get(function() {
+      var serializedData = null;
       try {
-        return JSON.parse(this._serialized);
+        if (this._serialized) {
+          serializedData = JSON.parse(this._serialized);
+        } else {
+          console.warn("No '_serialized' field found for app '%s'.", this.name);
+        }
       } catch (e) {
-        return {};
+        console.warn("Unable to parse '_serialized' field into JSON for app '%s'.", this.name);
       }
+      return serializedData;
     });
   }
-
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Experiments Dashboard for Frontier",
   "main": "app.js",
   "author": "Dan Crews <crewsd@gmail.com>",


### PR DESCRIPTION
# Problem space:
- Apps created or last updated with Feature v0.8.1 and prior do not have the _serialized field, which is required as of v0.9.0.
 
# Changes:
- [ ] Check if the _serialized field is missing.  If it is, the app is rewritten to the database, which causes the _serialized field to be created.
- [ ] Changed package.json version to 0.10.1.
 
# Should:
- [ ] Write the _serialized field for the app to the database. 