### PR TITLE
Another _serialized bug where the list of envs is incomplete

### DIFF
--- a/lib/models/app/methods.js
+++ b/lib/models/app/methods.js
@@ -54,11 +54,12 @@ function generateSerialized() {
 
         // Sets Groups list
         if (typeof val === 'object' && typeof val.length === 'number') {
-          return (envs[ref][name] = val.map(cleanGroupList));
+          envs[ref][name] = val.map(cleanGroupList);
+          continue;
         }
 
         // Set the booleans
-        return (envs[ref][name] = val);
+        envs[ref][name] = val;
       }
     }
   });
@@ -71,8 +72,6 @@ function serialize(cb) {
     , doc = this;
 
   this.generateSerialized();
-
-  var serialized = this.serialized;
 
   this.save(function(err) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Experiments Dashboard for Frontier",
   "main": "app.js",
   "author": "Dan Crews <crewsd@gmail.com>",


### PR DESCRIPTION
# Problem space:
- The _serialized field is only getting the first env for an experiment.
 
# Changes:
- [ ] Fixed the loop which writes the envs to not exit after the first iteration.
- [ ] Changed package.json version to 0.10.2.
 
# Should:
- [ ] Write all envs for the experiment to the _serialized field. 