### PR TITLE
Pinning to xpr-util-validation 0.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpr-dashboard",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Experiments Dashboard for Frontier",
   "main": "app.js",
   "author": "Dan Crews <crewsd@gmail.com>",
@@ -19,7 +19,7 @@
     "stylus": "^0.47.1",
     "superagent": "^0.18.1",
     "superagent-defaults": "^0.1.6",
-    "xpr-util-validation": "^0.0.1"
+    "xpr-util-validation": "git+https://github.com/fs-webdev/xpr-util-validation.js.git#0.1.0"
   },
   "devDependencies": {
     "chai": "^1.9.2",


### PR DESCRIPTION
Pinning to xpr-util-validation 0.1.0, which enforces alpha-numeric experiment names.